### PR TITLE
Net::ReadTimeout causing entire proxy fetch list to fail

### DIFF
--- a/spec/proxy_fetcher/version_spec.rb
+++ b/spec/proxy_fetcher/version_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe ProxyFetcher::VERSION do
-  it { expect(ProxyFetcher::VERSION::STRING).to eq '0.6.4' }
+  it { expect(ProxyFetcher::VERSION::STRING).to eq '0.6.5' }
 end


### PR DESCRIPTION
Fixes #21 
If for some reason one of the providers is not reachable the entire process crash. This is not good because there could be plenty of providers available to fetch proxies from. This fixes the issue by not crashing if there are some which are not reachable.