### PR TITLE
Timeout improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ Reverse Chronological Order:
 
 ## `master`
 
-* Add your changelog here
+* Fix a problem with stuck of proxies list loading.
+
+* Add a possibility to configure different timeouts for different cases:
+  - `client_timeout` - timeout for `ProxyFetcher::Client`.
+  - `provider_proxies_load_timeout` - timeout for loading of proxies list by provider.
+  - `proxy_validation_timeout` - timeout for proxy validation with `ProxyFetcher::ProxyValidator`. 
+  
+  (old option `timeout` sets and returns value of `client_timeout`)
 
 ## `0.8.0` (2018-11-12)
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,9 @@ ProxyFetcher.configure do |config|
   config.logger = Logger.new(STDOUT)
   config.user_agent = ProxyFetcher::Configuration::DEFAULT_USER_AGENT
   config.pool_size = 10
-  config.timeout = 3
+  config.client_timeout = 3
+  config.provider_proxies_load_timeout = 30
+  config.proxy_validation_timeout = 3
   config.http_client = ProxyFetcher::HTTPClient
   config.proxy_validator = ProxyFetcher::ProxyValidator
   config.providers = ProxyFetcher::Configuration.registered_providers
@@ -283,20 +285,9 @@ ProxyFetcher.configure do |config|
 end
 ```
 
-You can change any of the options above. Let's look at this deeper.
+You can change any of the options above.
 
-To change open/read timeout for `cleanup!` and `connectable?` methods you need to change `timeout` options:
-
-```ruby
-ProxyFetcher.configure do |config|
-  config.timeout = 1 # default is 3
-end
-
-manager = ProxyFetcher::Manager.new
-manager.cleanup!
-```
-
-Also you can set your custom User-Agent string:
+For example, you can set your custom User-Agent string:
 
 ```ruby
 ProxyFetcher.configure do |config|
@@ -382,7 +373,7 @@ ProxyFetcher.config.pool_size = 50
 You can experiment with the threads pool size to find an optimal number of maximum threads count for you PC and OS.
 This will definitely give you some performance improvements.
 
-Moreover, the common proxy validation speed depends on `ProxyFetcher.config.timeout` option that is equal
+Moreover, the common proxy validation speed depends on `ProxyFetcher.config.proxy_validation_timeout` option that is equal
 to `3` by default. It means that gem will wait 3 seconds for the server answer to check if particular proxy is connectable.
 You can decrease this option to `1`, for example, and it will heavily increase proxy validation speed (**but remember**
 that some proxies could be connectable, but slow, so with this option you will clear proxy list from the proxies that

--- a/lib/proxy_fetcher.rb
+++ b/lib/proxy_fetcher.rb
@@ -54,7 +54,8 @@ module ProxyFetcher
     #   ProxyFetcher.config
     #
     #   #=> #<ProxyFetcher::Configuration:0x0000000241eec8 @user_agent="Mozilla/5.0, ...", @pool_size=10,
-    #           @timeout=3, @http_client=ProxyFetcher::HTTPClient, @proxy_validator=ProxyFetcher::ProxyValidator,
+    #           @client_timeout=3, @proxy_validation_timeout=3, @provider_proxies_load_timeout=30,
+    #           @http_client=ProxyFetcher::HTTPClient, @proxy_validator=ProxyFetcher::ProxyValidator,
     #           @providers=[:free_proxy_list, ...], @adapter=ProxyFetcher::Document::NokogiriAdapter>
     #
     def config

--- a/lib/proxy_fetcher/client/request.rb
+++ b/lib/proxy_fetcher/client/request.rb
@@ -56,7 +56,7 @@ module ProxyFetcher
         @method = args.fetch(:method).to_s.downcase
         @headers = (args[:headers] || {}).dup
         @payload = args[:payload]
-        @timeout = args.fetch(:timeout, ProxyFetcher.config.timeout)
+        @timeout = args.fetch(:timeout, ProxyFetcher.config.client_timeout)
         @ssl_options = args.fetch(:ssl_options, default_ssl_options)
 
         @proxy = args.fetch(:proxy)

--- a/lib/proxy_fetcher/configuration.rb
+++ b/lib/proxy_fetcher/configuration.rb
@@ -5,9 +5,21 @@ module ProxyFetcher
   # with HTTP requests, adapters, custom classes.
   #
   class Configuration
-    # @!attribute timeout
-    #   @return [Integer] HTTP request connection / open timeout
-    attr_accessor :timeout
+    # @!attribute client_timeout
+    #   @return [Integer] HTTP request timeout (connect / open) for [ProxyFetcher::Client]
+    attr_accessor :client_timeout
+
+    # @!attribute provider_proxies_load_timeout
+    #   @return [Integer] HTTP request timeout (connect / open) for loading of proxies list by provider
+    attr_accessor :provider_proxies_load_timeout
+
+    # @!attribute proxy_validation_timeout
+    #   @return [Integer] HTTP request timeout (connect / open) for proxy validation with [ProxyFetcher::ProxyValidator]
+    attr_accessor :proxy_validation_timeout
+
+    # to save compatibility
+    alias timeout client_timeout
+    alias timeout= client_timeout=
 
     # @!attribute pool_size
     #   @return [Integer] proxy validator pool size (max number of threads)
@@ -98,7 +110,10 @@ module ProxyFetcher
       @logger = Logger.new(STDOUT)
       @user_agent = DEFAULT_USER_AGENT
       @pool_size = 10
-      @timeout = 3
+      @client_timeout = 3
+      @provider_proxies_load_timeout = 30
+      @proxy_validation_timeout = 3
+
       @http_client = HTTPClient
       @proxy_validator = ProxyValidator
 

--- a/lib/proxy_fetcher/utils/proxy_validator.rb
+++ b/lib/proxy_fetcher/utils/proxy_validator.rb
@@ -28,7 +28,7 @@ module ProxyFetcher
     # @return [ProxyValidator]
     #
     def initialize(proxy_addr, proxy_port)
-      timeout = ProxyFetcher.config.timeout
+      timeout = ProxyFetcher.config.proxy_validation_timeout
 
       @http = HTTP.follow.via(proxy_addr, proxy_port.to_i).timeout(connect: timeout, read: timeout)
     end

--- a/spec/proxy_fetcher/client/client_spec.rb
+++ b/spec/proxy_fetcher/client/client_spec.rb
@@ -10,7 +10,7 @@ xdescribe ProxyFetcher::Client do
   before :all do
     ProxyFetcher.configure do |config|
       config.provider = :xroxy
-      config.timeout = 5
+      config.client_timeout = 5
     end
 
     @server = EvilProxy::MITMProxyServer.new Port: 3128, Quiet: true


### PR DESCRIPTION
Hello, Nikita!

This PR resolves some issues described below.

First, the code of loading proxies list by adapters doesn't use HTTP timeouts.
Timeout is important there because allows preventing a stuck while loading proxies.

The second point is that only one option `timeout` is available to configure timeout.
It seems that it's better to use different options to set timeouts for different cases.

Following timeout options are implemented:
  - `client_timeout` - timeout for `ProxyFetcher::Client`.
  - ~~`load_provider_proxies_timeout`~~ `provider_proxies_load_timeout`  - timeout for loading of proxies list by provider.
  - ~~`validate_proxy_timeout`~~ `proxy_validation_timeout`  - timeout for proxy validation with `ProxyFetcher::ProxyValidator`. 

   (old option `timeout` sets and returns value of `client_timeout`)